### PR TITLE
feat: Split config settings into base, dev and prod

### DIFF
--- a/backend/candleaf/store/views.py
+++ b/backend/candleaf/store/views.py
@@ -6,7 +6,7 @@ from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 
-from config import settings
+from config.settings import base as settings
 from candleaf.core.serializers import CreateUserSerializer
 from . import models, serializers, filters
 from .paginations import PageNumberPagination

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -10,18 +10,14 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 
-import os
-from datetime import timedelta
 from pathlib import Path
-from decouple import config
-import stripe
-from django.conf import settings
+from urllib.parse import quote
 
 # Hack workaround for deprecated/removed functions
 import django
-from django.utils.encoding import force_str
-from urllib.parse import quote
+from decouple import config
 from django.utils import http
+from django.utils.encoding import force_str
 
 django.utils.encoding.force_text = force_str
 http.urlquote = quote
@@ -29,19 +25,9 @@ http.urlquote = quote
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
-
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-0+ma-70up$xfk-5-tgi1bj*3y6++07)1ib&ar5mauw(a7r^&x_'
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-ALLOWED_HOSTS = []
+SECRET_KEY = config("SECRET_KEY")
 
 # Application definition
-
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
@@ -92,16 +78,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'config.wsgi.application'
 
-# Database
-# https://docs.djangoproject.com/en/4.1/ref/settings/#databases
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
-    }
-}
-
 # Password validation
 # https://docs.djangoproject.com/en/4.1/ref/settings/#auth-password-validators
 
@@ -136,7 +112,6 @@ USE_TZ = True
 
 STATIC_URL = 'static/'
 MEDIA_URL = 'media/'
-MEDIA_ROOT = os.path.join(BASE_DIR, 'candleaf', 'media')
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
@@ -196,16 +171,3 @@ STRIPE_WEBHOOK_SECRET = config('STRIPE_WEBHOOK_SECRET')
 TEMPLATE_CONTEXT_PROCESSORS = (
     "django.core.context_processors.request",
 )
-
-if DEBUG:
-    SIMPLE_JWT["ACCESS_TOKEN_LIFETIME"] = timedelta(days=30)
-
-    CORS_ALLOWED_ORIGINS = [
-        'http://127.0.0.1:3000',
-        'http://localhost:3000',
-    ]
-
-    CORS_ALLOW_CREDENTIALS = True
-
-    SESSION_COOKIE_SECURE = False
-    SESSION_COOKIE_HTTPONLY = False

--- a/backend/config/settings/dev.py
+++ b/backend/config/settings/dev.py
@@ -1,0 +1,31 @@
+# noinspection PyUnresolvedReferences
+from .base import *
+
+import os
+from datetime import timedelta
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+ALLOWED_HOSTS = []
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR / 'db.sqlite3',
+    }
+}
+
+MEDIA_ROOT = os.path.join(BASE_DIR, 'candleaf', 'media')
+
+SIMPLE_JWT["ACCESS_TOKEN_LIFETIME"] = timedelta(days=30)
+
+CORS_ALLOWED_ORIGINS = [
+    'http://127.0.0.1:3000',
+    'http://localhost:3000',
+]
+
+CORS_ALLOW_CREDENTIALS = True
+
+SESSION_COOKIE_SECURE = False
+SESSION_COOKIE_HTTPONLY = False

--- a/backend/config/settings/prod.py
+++ b/backend/config/settings/prod.py
@@ -1,0 +1,28 @@
+from .base import *
+
+from decouple import config
+
+ALLOWED_HOSTS = []
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR / 'db.sqlite3',
+    }
+}
+
+# aws settings
+AWS_ACCESS_KEY_ID = config('AWS_ACCESS_KEY_ID')
+AWS_SECRET_ACCESS_KEY = config('AWS_SECRET_ACCESS_KEY')
+AWS_STORAGE_BUCKET_NAME = config('AWS_STORAGE_BUCKET_NAME')
+AWS_DEFAULT_ACL = None
+AWS_S3_CUSTOM_DOMAIN = f'{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com'
+AWS_S3_OBJECT_PARAMETERS = {'CacheControl': 'max-age=86400'}
+# s3 static settings
+STATIC_LOCATION = 'static'
+STATIC_URL = f'https://{AWS_S3_CUSTOM_DOMAIN}/{STATIC_LOCATION}/'
+STATICFILES_STORAGE = 'hello_django.storage_backends.StaticStorage'
+# s3 public media settings
+PUBLIC_MEDIA_LOCATION = 'media'
+MEDIA_URL = f'https://{AWS_S3_CUSTOM_DOMAIN}/{PUBLIC_MEDIA_LOCATION}/'
+DEFAULT_FILE_STORAGE = 'hello_django.storage_backends.PublicMediaStorage'

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.prod')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
Separated Django's configuration settings into base, development and production settings. The move aims to ensure better separation of concerns for different environments, improve code maintainability and enhance security by handling sensitive keys using the python-decouple library in production.

Import statements that were affected in the apps due to this change have been updated accordingly.

Added the settings for AWS S3 bucket for file storage in the production setting.

This restructuring allows us to vary configurations easily between development and production environment.